### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "keyspace-plugin",
-  "version": "0.1.0",
-  "private": true,
+  "version": "1.0.0",
+  "private": false,
   "dependencies": {
     "@chakra-ui/icons": "^2.0.0",
     "@chakra-ui/react": "^2.4.4",


### PR DESCRIPTION


## 📋 : Release Notes

* Bump version to `1.0.0`
* Set `private` to false in `package.json`
