### PR TITLE
fix: type mismatch for rtk query transform response params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyspace-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "dependencies": {
     "@chakra-ui/icons": "^2.0.0",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,7 +62,7 @@ export const api = createApi({
             query: () => 'vaults/items?combined=true',
             transformResponse: async (
                 response: VaultItemsResponse,
-                meta: {},
+                meta: undefined,
                 arg: Uint8Array
             ) => {
                 const decryptionKey = arg


### PR DESCRIPTION
## 📋 : Release Notes

* Fixed a type mismatch in RTK query's `transformResponse` parameters

