### PR TITLE
feat: handle session persistence for manifest version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ The browser plugin for [Keyspace](https://keyspace.cloud) - A secure self-custod
 `yarn`
 
 ### Build
-Build for manifest version 2 with `yarn build`
+Build webapp with `yarn build`
 
-Build for manifest version 3 with `yarn v3build`
+Build for manifest version 2 with `yarn build:mv2`
+
+Build for manifest version 3 with `yarn build:mv3`
 
 ### Rebuild icon manifest
 

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,8 +1,19 @@
 const webpack = require('webpack')
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const manifestVersion = process.env.MANIFEST_VERSION == 3 ? 3 : 2
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
-console.log(`Building for manifest version ${manifestVersion}`)
+const manifestVersion = Number(process.env.MANIFEST_VERSION)
+const copyPluginOptions = []
+
+if (manifestVersion) {
+    console.log(`Building for manifest version ${manifestVersion}`)
+    if (manifestVersion === 2) {
+        copyPluginOptions.push('./src/manifest.json')
+    } else
+        copyPluginOptions.push({
+            from: './src/manifest.v3.json',
+            to: 'manifest.json',
+        })
+}
 
 module.exports = function override(config, env) {
     config.resolve.fallback = {
@@ -23,13 +34,6 @@ module.exports = function override(config, env) {
         new webpack.optimize.AggressiveSplittingPlugin({
             minSize: 20000,
             maxSize: 50000,
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
-                manifestVersion == 3
-                    ? { from: './src/manifest.v3.json', to: 'manifest.json' }
-                    : './src/manifest.json',
-            ],
         })
     )
     config.module.rules.push({
@@ -38,6 +42,13 @@ module.exports = function override(config, env) {
             fullySpecified: false,
         },
     })
+
+    if (copyPluginOptions.length)
+        config.plugins.push(
+            new CopyWebpackPlugin({
+                patterns: copyPluginOptions,
+            })
+        )
 
     return config
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
-    "v3build": "cross-env MANIFEST_VERSION=3 react-app-rewired build",
+    "build:mv2": "cross-env MANIFEST_VERSION=2 react-app-rewired build",
+    "build:mv3": "cross-env MANIFEST_VERSION=3 react-app-rewired build",
     "build-icons": "node build-icons.js",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyspace-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "dependencies": {
     "@chakra-ui/icons": "^2.0.0",

--- a/src/components/App/Layout/Sidebar.tsx
+++ b/src/components/App/Layout/Sidebar.tsx
@@ -45,7 +45,7 @@ export const Sidebar = (props: SidebarProps) => {
                 console.log('Error syncing with background script:', error)
             }
         }
-        else {
+        else if(manifestVersion() === 3) {
             try {
                 chrome.storage.session.clear()
             } catch(error) {

--- a/src/components/App/Layout/Sidebar.tsx
+++ b/src/components/App/Layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import { useAppSelector, useAppDispatch } from '../../../store/hooks'
 import { removeSession } from '../../../store/reducers/auth'
 import { View } from '../../../types'
 import { Logo } from '../../../Logo'
+import { manifestVersion } from '../../../utils/browser'
 
 interface SidebarProps {
     toggleSidebar?: Function
@@ -30,18 +31,28 @@ export const Sidebar = (props: SidebarProps) => {
     const dispatch = useAppDispatch()
 
     const endSession = () => {
-        try {
-            chrome.runtime.sendMessage(
-                { cmd: 'removeSession' },
-                function (response) {
-                    console.log(
-                        `message from background: ${JSON.stringify(response)}`
-                    )
-                }
-            )
-        } catch (error) {
-            console.log('Error syncing with background script:', error)
+        if (manifestVersion() === 2) {
+            try {
+                chrome.runtime.sendMessage(
+                    { cmd: 'removeSession' },
+                    function (response) {
+                        console.log(
+                            `message from background: ${JSON.stringify(response)}`
+                        )
+                    }
+                )
+            } catch (error) {
+                console.log('Error syncing with background script:', error)
+            }
         }
+        else {
+            try {
+                chrome.storage.session.clear()
+            } catch(error) {
+                console.log('Error clearing session storage', error)
+            }
+        }
+        
         dispatch(removeSession())
     }
 

--- a/src/components/Authentication/Keyroute.tsx
+++ b/src/components/Authentication/Keyroute.tsx
@@ -125,9 +125,7 @@ export const Keyroute = () => {
                         keyring: {
                             publicKey: hex2buf(session.keyring.publicKey),
                             privateKey: hex2buf(session.keyring.privateKey),
-                            symmetricKey: hex2buf(
-                                session.keyring.symmetricKey
-                            ),
+                            symmetricKey: hex2buf(session.keyring.symmetricKey),
                         },
                     }
                     dispatch(addSession(decodedSessionData))
@@ -138,7 +136,7 @@ export const Keyroute = () => {
         }
         if (manifestVersion() === 2) {
             getSessionFromBackgroundScript()
-        } else {
+        } else if (manifestVersion() === 3) {
             getSessionFromStorage()
         }
     }, [dispatch])
@@ -234,7 +232,7 @@ export const Keyroute = () => {
                                     error
                                 )
                             }
-                        } else {
+                        } else if(manifestVersion() === 3) {
                             try {
                                 await chrome.storage.session.set({
                                     session: encodedSessionData,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,16 +25,12 @@
   "permissions": [
     "tabs",
     "activeTab",
-    "contextMenus",
     "storage",
     "unlimitedStorage",
     "clipboardRead",
     "clipboardWrite",
-    "idle",
     "http://*/*",
-    "https://*/*",
-    "webRequest",
-    "webRequestBlocking"
+    "https://*/*"
   ],
   "commands": {
       "_execute_browser_action": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" :"Keyspace",
   "description": "Keyspace wallet browser add-on",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "manifest_version": 2,
   "icons": {
       "16": "./images/favicon-16x16.png",

--- a/src/manifest.v3.json
+++ b/src/manifest.v3.json
@@ -1,7 +1,7 @@
 {
     "name" :"Keyspace",
     "description": "Keyspace wallet browser add-on",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "manifest_version": 3,
     "icons": {
         "16": "./images/favicon-16x16.png",

--- a/src/manifest.v3.json
+++ b/src/manifest.v3.json
@@ -24,15 +24,12 @@
     "permissions": [
       "tabs",
       "activeTab",
-      "contextMenus",
       "storage",
       "unlimitedStorage",
       "clipboardRead",
       "clipboardWrite",
-      "idle",
       "http://*/*",
-      "https://*/*",
-      "webRequest"
+      "https://*/*"
     ],
     "commands": {
         "_execute_browser_action": {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -23,8 +23,12 @@ export const tabsQuery = (
 /**
  * Returns the manifest version
  * 
- * @returns {2 | 3}
+ * @returns {2 | 3 | null}
  */
 export const manifestVersion = () => {
-    return chrome.runtime.getManifest().manifest_version;
+    try {
+        return chrome.runtime.getManifest().manifest_version;
+    } catch(e) {
+        return null
+    }
 }

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -19,3 +19,12 @@ export const tabsQuery = (
         }
     })
 }
+
+/**
+ * Returns the manifest version
+ * 
+ * @returns {2 | 3}
+ */
+export const manifestVersion = () => {
+    return chrome.runtime.getManifest().manifest_version;
+}


### PR DESCRIPTION
## :recycle: Current situation

The current implementation of session persistence leverages persistent background scripts. However manifest version 3 deprecates persistent background scripts in favor of [service workers](https://developer.chrome.com/docs/extensions/mv3/mv3-migration/#background-service-workers). As a result, session persistence does not work on Chrome and Chromium based browsers

## :bulb: Proposed solution

Leverage `chrome.storage.session`, newly added in MV3 to persist user sessions. The session storage is held in memory and never written to disk, preserving the same threat model as persistent background scripts. Ref: https://developer.chrome.com/docs/extensions/reference/storage/#property-session

## 📋 : Release Notes

* Cleaned up unused permissions from the manifest
* Added a util to determine the manifest version of the current build
* Added logic to handle storing, getting and clearing session data to session storage for MV3 builds.
* Update webpack config to handle builds separately for no manifest version env var, manifest 2 and 3 (manifest file is no longer bundled for standard web builds)
* Update build scripts. The app can now be built in 3 different ways:
  * `yarn build` does a standard webapp build without any manifest
  * `yarn build:mv2` does a plugin build for manifest version 2 for Firefox
  * `yarn build:mv3` does a plugin build for manifest version 3 for Chrome and Chromium browsers 
